### PR TITLE
WIP: Add further condition options for handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msw-when-then",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A non-invasive 'when-then' style API for MSW",
   "main": "src/index.js",
   "scripts": {

--- a/src/Request.js
+++ b/src/Request.js
@@ -1,0 +1,12 @@
+const request = (...requestData) => Object.assign({}, ...requestData);
+
+const withBody = (body) => ({ body });
+const withHeaders = (headers) => ({ headers });
+const withParams = (params) => ({ params });
+
+module.exports = {
+  request,
+  withBody,
+  withHeaders,
+  withParams,
+};

--- a/src/Request.test.js
+++ b/src/Request.test.js
@@ -1,0 +1,21 @@
+const { request, withBody, withHeaders, withParams } = require("./Request");
+
+test("request merges objects", () => {
+  expect(request({ first: 1 }, { second: 2 })).toStrictEqual({ first: 1, second: 2 });
+});
+
+test("withBody create object with body key", () => {
+  expect(withBody({ someKey: "some value" })).toStrictEqual({ body: { someKey: "some value" } });
+});
+
+test("withHeaders create object with headers key", () => {
+  expect(withHeaders({ someKey: "some value" })).toStrictEqual({
+    headers: { someKey: "some value" },
+  });
+});
+
+test("withParams create object with params key", () => {
+  expect(withParams({ someKey: "some value" })).toStrictEqual({
+    params: { someKey: "some value" },
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -8,15 +8,8 @@ const {
   notFound,
   response,
 } = require("./Responses");
-const {
-  get,
-  post,
-  put,
-  _delete,
-  patch,
-  options,
-  mask,
-} = require("./RestMethods");
+const { get, post, put, _delete, patch, options, mask } = require("./RestMethods");
+const { request, withBody, withHeaders, withParams } = require("./Request");
 
 module.exports = {
   whenThen,
@@ -34,4 +27,8 @@ module.exports = {
   patch,
   options,
   mask,
+  request,
+  withBody,
+  withHeaders,
+  withParams,
 };

--- a/tests/MswWhenTest.test.js
+++ b/tests/MswWhenTest.test.js
@@ -1,6 +1,6 @@
 const { rest } = require("msw");
 const { setupServer } = require("msw/node");
-const { whenThen, get, ok } = require("../src");
+const { whenThen, get, post, ok, request, withBody, withHeaders, withParams } = require("../src");
 const fetch = require("node-fetch");
 
 const server = setupServer();
@@ -11,12 +11,12 @@ beforeAll(() => server.listen());
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-const fetchExample = () => fetch("https://example.com").then((res) => res);
+const httpRequest = (path, init) => fetch(path, init).then((res) => res);
 
 test("mocks response with thenReturn", async () => {
   when(get("https://example.com")).thenReturn(ok({ response: "success" }));
 
-  const response = await fetchExample();
+  const response = await httpRequest("https://example.com");
   const json = await response.json();
 
   expect(response.status).toBe(200);
@@ -26,13 +26,13 @@ test("mocks response with thenReturn", async () => {
 test("mocks response with thenReturn for multiple fetches", async () => {
   when(get("https://example.com")).thenReturn(ok({ response: "success" }));
 
-  const response = await fetchExample();
+  const response = await httpRequest("https://example.com");
   const json = await response.json();
 
   expect(response.status).toBe(200);
   expect(json).toStrictEqual({ response: "success" });
 
-  const response2 = await fetchExample();
+  const response2 = await httpRequest("https://example.com");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
@@ -44,7 +44,7 @@ test("mocks response with then", async () => {
     res(ctx.status(200), ctx.json({ response: "success" }))
   );
 
-  const response = await fetchExample();
+  const response = await httpRequest("https://example.com");
   const json = await response.json();
 
   expect(response.status).toBe(200);
@@ -56,15 +56,143 @@ test("mocks response with then for multiple fetches", async () => {
     res(ctx.status(200), ctx.json({ response: "success" }))
   );
 
-  const response = await fetchExample();
+  const response = await httpRequest("https://example.com");
   const json = await response.json();
 
   expect(response.status).toBe(200);
   expect(json).toStrictEqual({ response: "success" });
 
-  const response2 = await fetchExample();
+  const response2 = await httpRequest("https://example.com");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
   expect(json2).toStrictEqual({ response: "success" });
+});
+
+test("mocking response with empty request data acts like thenReturn", async () => {
+  when(post("https://example.com")).thenReturnFor(request(), ok({ response: "success" }));
+
+  const response = await httpRequest("https://example.com", {
+    method: "POST",
+  });
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json).toStrictEqual({ response: "success" });
+});
+
+test("mocks response including body data", async () => {
+  when(post("https://example.com")).thenReturnFor(
+    request(withBody({ "some-key": "some value" })),
+    ok({ response: "success" })
+  );
+
+  const body = JSON.stringify({ "some-key": "some value" });
+  const response = await httpRequest("https://example.com", {
+    method: "POST",
+    body,
+  });
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json).toStrictEqual({ response: "success" });
+});
+
+test("mocks response including header data", async () => {
+  when(post("https://example.com")).thenReturnFor(
+    request(withHeaders({ "some-key": "some value" })),
+    ok({ response: "success" })
+  );
+
+  const headers = { "some-key": "some value" };
+  const response = await httpRequest("https://example.com", {
+    method: "POST",
+    headers,
+  });
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json).toStrictEqual({ response: "success" });
+});
+
+test("mocks response including params", async () => {
+  when(post("https://example.com/:id")).thenReturnFor(
+    request(withParams({ id: "some-id" })),
+    ok({ response: "success" })
+  );
+
+  const response = await httpRequest("https://example.com/some-id", {
+    method: "POST",
+  });
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json).toStrictEqual({ response: "success" });
+});
+
+test("mocks response including body, headers and params", async () => {
+  when(post("https://example.com/:id")).thenReturnFor(
+    request(
+      withBody({ "some-body-key": "some body value" }),
+      withHeaders({ "some-header-key": "some header value" }),
+      withParams({ id: "some-id" })
+    ),
+    ok({ response: "success" })
+  );
+
+  const body = JSON.stringify({ "some-body-key": "some body value" });
+  const headers = { "some-header-key": "some header value" };
+  const response = await httpRequest("https://example.com/some-id", {
+    method: "POST",
+    body,
+    headers,
+  });
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json).toStrictEqual({ response: "success" });
+});
+
+test("mocks response fails without correct body data", async () => {
+  when(post("https://example.com")).thenReturnFor(
+    request(withBody({ "some-key": "some value" })),
+    ok({ response: "success" })
+  );
+
+  const testRequest = async () =>
+    await httpRequest("https://example.com", {
+      method: "POST",
+      body: JSON.stringify({ "some-other-key": "some other value" }),
+    });
+
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("mocks response fails without correct header data", async () => {
+  when(post("https://example.com")).thenReturnFor(
+    request(withHeaders({ "some-header-key": "some header value" })),
+    ok({ response: "success" })
+  );
+
+  const testRequest = async () =>
+    await httpRequest("https://example.com", {
+      method: "POST",
+      headers: { "some-other-header-key": "some other header value" },
+    });
+
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("mocks response fails without correct params", async () => {
+  when(post("https://example.com/:id")).thenReturnFor(
+    request(withParams({ id: "some-id" })),
+    ok({ response: "success" })
+  );
+
+  const testRequest = async () =>
+    await httpRequest("https://example.com/some-other-id", {
+      method: "POST",
+    });
+
+  await expect(testRequest()).rejects.toThrow();
 });


### PR DESCRIPTION
Something that is currently missing is the ability to test if the http
request is being called with the correct request data
(body/headers/params).

This commit addresses that by giving the option to add request data to
the handlers. This will allow mocks to only responses for specific data
set.

- A couple of things still to be done: Add more tests for failure
scenarios.
- Regex matching (e.g. checking that a header/param exists, but not
caring about the value)
- Default failure behaviour. Star matcher?