### PR TITLE
Add CI test pipeline

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,24 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test -- --watchAll=false


### PR DESCRIPTION
We need a CI pipeline to make sure I dont break stuff (which happens
often). This is a good starting point, simply using the workflow
suggested by github for testing against multiple node versions which is
found here: https://github.com/actions/starter-workflows/blob/60765e84900ccf192eadf19a9459e67566ffaabe/ci/node.js.yml.

Note: Remove the build step as it is not needed for now.