### PR TITLE
Add ability to specify search params

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -3,10 +3,12 @@ const request = (...requestData) => Object.assign({}, ...requestData);
 const withBody = (body) => ({ body });
 const withHeaders = (headers) => ({ headers });
 const withParams = (params) => ({ params });
+const withSearchParams = (searchParams) => ({ searchParams });
 
 module.exports = {
   request,
   withBody,
   withHeaders,
   withParams,
+  withSearchParams,
 };

--- a/src/WhenThen.js
+++ b/src/WhenThen.js
@@ -1,7 +1,16 @@
-const isEqual = require('lodash.isequal');
+const isEqual = require("lodash.isequal");
 
 const contains = (obj, source) =>
   Object.keys(source).every((key) => obj.hasOwnProperty(key) && obj[key] === source[key]);
+
+const searchParamsContains = (searchParams, requestSearchParams) =>
+  Object.keys(requestSearchParams).every((key) => {
+    const requestParamValue = requestSearchParams[key];
+    const paramValue = Array.isArray(requestParamValue)
+      ? searchParams.getAll(key)
+      : searchParams.get(key);
+    return isEqual(paramValue, requestParamValue);
+  });
 
 const whenThen = (server, rest) => {
   const when = ({ method, url }) => {
@@ -15,12 +24,18 @@ const whenThen = (server, rest) => {
     };
 
     const thenReturnFor = (request, { status, body: responseBody = null }) => {
-      const { body: requestBody, headers: requestHeaders, params: requestParams } = request;
+      const {
+        body: requestBody,
+        headers: requestHeaders,
+        params: requestParams,
+        searchParams: requestSearchParams,
+      } = request;
 
       const resolver = (req, res, context) =>
         (!requestBody || isEqual(req.body, requestBody)) &&
         (!requestHeaders || contains(req.headers.map, requestHeaders)) &&
         (!requestParams || isEqual({ ...req.params }, requestParams)) &&
+        (!requestSearchParams || searchParamsContains(req.url.searchParams, requestSearchParams)) &&
         res(context.status(status), context.json(responseBody));
 
       resolvers.push(resolver);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const {
   response,
 } = require("./Responses");
 const { get, post, put, _delete, patch, options, mask } = require("./RestMethods");
-const { request, withBody, withHeaders, withParams } = require("./Request");
+const { request, withBody, withHeaders, withParams, withSearchParams } = require("./Request");
 
 module.exports = {
   whenThen,
@@ -31,4 +31,5 @@ module.exports = {
   withBody,
   withHeaders,
   withParams,
+  withSearchParams,
 };


### PR DESCRIPTION
Currently there is no way to specify search params
expected by a request. Add a `withSearchParams`
function that allows the user to specify this.