### PR TITLE
Add graphql utilities

### DIFF
--- a/src/GraphQLActions.js
+++ b/src/GraphQLActions.js
@@ -1,0 +1,9 @@
+const mask = (action, actionName) => ({ action, actionName });
+
+const query = (queryName) => mask("query", queryName);
+const mutation = (mutationName) => mask("mutation", mutationName);
+
+module.exports = {
+  query,
+  mutation,
+};

--- a/src/Responses.js
+++ b/src/Responses.js
@@ -7,8 +7,8 @@ const badRequest = (body = null) => response(400, body);
 const unauthorized = (body = null) => response(401, body);
 const notFound = (body = null) => response(404, body);
 
-const data = (body) => ({responseBody: body})
-const errors = (errors) => ({errors})
+const data = (body) => ({ responseBody: body });
+const errors = (errors) => ({ errors });
 
 module.exports = {
   ok,

--- a/src/Responses.js
+++ b/src/Responses.js
@@ -7,6 +7,9 @@ const badRequest = (body = null) => response(400, body);
 const unauthorized = (body = null) => response(401, body);
 const notFound = (body = null) => response(404, body);
 
+const data = (body) => ({responseBody: body})
+const errors = (errors) => ({errors})
+
 module.exports = {
   ok,
   created,
@@ -15,4 +18,6 @@ module.exports = {
   unauthorized,
   notFound,
   response,
+  data,
+  errors,
 };

--- a/src/WhenThenGraphQL.js
+++ b/src/WhenThenGraphQL.js
@@ -1,5 +1,3 @@
-const isEqual = require("lodash.isequal");
-
 const contains = (obj, source) =>
   Object.keys(source).every(
     (key) => obj.hasOwnProperty(key) && obj[key] === source[key]
@@ -10,25 +8,26 @@ const whenThenGraphQL = (server, graphql) => {
     let count = 0;
     let resolvers = [];
 
-    const thenReturn = ({responseBody, errors=[]}) => {
+    const thenReturn = ({ responseBody, errors = [] }) => {
       const resolver = (req, res, context) => {
-        return (errors.length > 0) 
+        return errors.length > 0
           ? res(context.errors(errors))
           : res(context.data(responseBody));
-      }
+      };
       resolvers.push(resolver);
       return thenFunctions;
     };
 
-    const thenReturnFor = (request, {responseBody, errors=[]}) => {
-      const {
-        headers: requestHeaders,
-      } = request;
+    const thenReturnFor = (request, { responseBody, errors = [] }) => {
+      const { headers: requestHeaders } = request;
 
       const resolver = (req, res, context) =>
         (!requestHeaders || contains(req.headers.map, requestHeaders)) &&
-        res(context.status(status), 
-        (errors.length > 0) ? context.errors(errors) : context.data(responseBody)
+        res(
+          context.status(status),
+          errors.length > 0
+            ? context.errors(errors)
+            : context.data(responseBody)
         );
 
       resolvers.push(resolver);
@@ -39,16 +38,18 @@ const whenThenGraphQL = (server, graphql) => {
       resolvers.push(resolver);
       return thenFunctions;
     };
-    
+
     const thenFunctions = { thenReturn, thenReturnFor, then };
-    
+
     const resolver = (count) =>
       count > resolvers.length - 1
         ? resolvers[resolvers.length - 1]
         : resolvers[count];
 
     server.use(
-      graphql[action](actionName, (req, res, ctx) => resolver(count++)(req, res, ctx)),
+      graphql[action](actionName, (req, res, ctx) =>
+        resolver(count++)(req, res, ctx)
+      )
     );
 
     return thenFunctions;

--- a/src/WhenThenGraphQL.js
+++ b/src/WhenThenGraphQL.js
@@ -1,0 +1,60 @@
+const isEqual = require("lodash.isequal");
+
+const contains = (obj, source) =>
+  Object.keys(source).every(
+    (key) => obj.hasOwnProperty(key) && obj[key] === source[key]
+  );
+
+const whenThenGraphQL = (server, graphql) => {
+  const when = ({ action, actionName }) => {
+    let count = 0;
+    let resolvers = [];
+
+    const thenReturn = ({responseBody, errors=[]}) => {
+      const resolver = (req, res, context) => {
+        return (errors.length > 0) 
+          ? res(context.errors(errors))
+          : res(context.data(responseBody));
+      }
+      resolvers.push(resolver);
+      return thenFunctions;
+    };
+
+    const thenReturnFor = (request, {responseBody, errors=[]}) => {
+      const {
+        headers: requestHeaders,
+      } = request;
+
+      const resolver = (req, res, context) =>
+        (!requestHeaders || contains(req.headers.map, requestHeaders)) &&
+        res(context.status(status), 
+        (errors.length > 0) ? context.errors(errors) : context.data(responseBody)
+        );
+
+      resolvers.push(resolver);
+      return thenFunctions;
+    };
+
+    const then = (resolver = () => {}) => {
+      resolvers.push(resolver);
+      return thenFunctions;
+    };
+    
+    const thenFunctions = { thenReturn, thenReturnFor, then };
+    
+    const resolver = (count) =>
+      count > resolvers.length - 1
+        ? resolvers[resolvers.length - 1]
+        : resolvers[count];
+
+    server.use(
+      graphql[action](actionName, (req, res, ctx) => resolver(count++)(req, res, ctx)),
+    );
+
+    return thenFunctions;
+  };
+
+  return { when };
+};
+
+module.exports = whenThenGraphQL;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 const whenThen = require("./WhenThen");
+const whenThenGraphQL = require("./WhenThenGraphQL");
 const {
   ok,
+  data,
+  errors,
   created,
   accepted,
   badRequest,
@@ -18,6 +21,10 @@ const {
   mask,
 } = require("./RestMethods");
 const {
+  query,
+  mutation,
+} = require("./GraphQLActions");
+const {
   request,
   withBody,
   withHeaders,
@@ -27,7 +34,10 @@ const {
 
 module.exports = {
   whenThen,
+  whenThenGraphQL,
   ok,
+  data,
+  errors,
   created,
   accepted,
   badRequest,
@@ -39,6 +49,8 @@ module.exports = {
   put,
   _delete,
   patch,
+  mutation,
+  query,
   options,
   mask,
   request,

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,7 @@ const {
   options,
   mask,
 } = require("./RestMethods");
-const {
-  query,
-  mutation,
-} = require("./GraphQLActions");
+const { query, mutation } = require("./GraphQLActions");
 const {
   request,
   withBody,

--- a/tests/MswWhenGraphQLTest.test.js
+++ b/tests/MswWhenGraphQLTest.test.js
@@ -52,6 +52,7 @@ const buildMutation = (queryName) => `
 
 const graphqlQuery = (queryName, options) =>
   graphqlAction("https://some.url", buildQuery(queryName), options);
+
 const graphqlMutation = (mutationName, options) =>
   graphqlAction("https://some.url", buildMutation(mutationName), options);
 

--- a/tests/MswWhenGraphQLTest.test.js
+++ b/tests/MswWhenGraphQLTest.test.js
@@ -1,0 +1,343 @@
+const { graphql } = require("msw");
+const { setupServer } = require("msw/node");
+const {
+  whenThenGraphQL,
+  data,
+  errors,
+  query,
+  mutation,
+  request,
+  withHeaders,
+} = require("../src");
+const fetch = require("node-fetch");
+
+const server = setupServer();
+
+const { when } = whenThenGraphQL(server, graphql);
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+const graphqlAction = (url, query, options={}) => {
+  const contentTypeHeader = { 'Content-Type': 'application/json'}
+  const headers = options.headers ? {...contentTypeHeader, ...options.headers} : contentTypeHeader;
+
+  const allOptions = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query })
+  }
+
+  return fetch(url, allOptions);
+}
+
+const buildQuery = (queryName) => `
+  query ${queryName} {
+    user {
+      id
+    }
+  }
+`;
+
+const buildMutation = (queryName) => `
+  mutation ${queryName} {
+    user {
+      id
+    }
+  }
+`;
+
+const graphqlQuery = (queryName, options) => 
+  graphqlAction("https://some.url", buildQuery(queryName), options);
+const graphqlMutation = (mutationName, options) => 
+  graphqlAction("https://some.url", buildMutation(mutationName), options);
+
+test("mocks query response with thenReturn", async () => {
+  when(query("TestQuery")).thenReturn(data({ response: "success" }));
+
+  const response = await graphqlQuery('TestQuery');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks mutation response with thenReturn", async () => {
+  when(mutation("TestMutation")).thenReturn(data({ response: "success" }));
+
+  const response = await graphqlMutation('TestMutation');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks query response with thenReturn for multiple fetches", async () => {
+  when(query("TestQuery")).thenReturn(data({ response: "success" }));
+
+  const response = await graphqlQuery('TestQuery');
+  const json = await response.json();
+  
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+  
+  const response2 = await graphqlQuery('TestQuery');
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks mutation response with thenReturn for multiple fetches", async () => {
+  when(mutation("TestMutation")).thenReturn(data({ response: "success" }));
+
+  const response = await graphqlMutation('TestMutation');
+  const json = await response.json();
+  
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+  
+  const response2 = await graphqlMutation('TestMutation');
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks query response with then", async () => {
+  when(query("TestQuery")).then((req, res, ctx) =>
+    res(ctx.data({ response: "success" }))
+  );
+
+  const response = await graphqlQuery('TestQuery');
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks mutation response with then", async () => {
+  when(mutation("TestMutation")).then((req, res, ctx) =>
+    res(ctx.data({ response: "success" }))
+  );
+
+  const response = await graphqlMutation('TestMutation');
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks query response with then for multiple fetches", async () => {
+  when(query("TestQuery")).then((req, res, ctx) =>
+    res(ctx.data({ response: "success" }))
+  );
+
+  const response = await graphqlQuery('TestQuery');
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+
+  const response2 = await graphqlQuery('TestQuery');
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks mutation response with then for multiple fetches", async () => {
+  when(mutation("TestMutation")).then((req, res, ctx) =>
+    res(ctx.data({ response: "success" }))
+  );
+
+  const response = await graphqlMutation('TestMutation');
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+
+  const response2 = await graphqlMutation('TestMutation');
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.data).toStrictEqual({ response: "success" });
+});
+
+test("mocking query response with empty request data acts like thenReturn", async () => {
+  when(query("TestQuery")).thenReturnFor(
+    request(),
+    data({ response: "success" })
+  );
+
+  const response = await graphqlQuery('TestQuery');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocking mutation response with empty request data acts like thenReturn", async () => {
+  when(mutation("TestMutation")).thenReturnFor(
+    request(),
+    data({ response: "success" })
+  );
+
+  const response = await graphqlMutation('TestMutation');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks query response including header data", async () => {
+  when(query("TestQuery")).thenReturnFor(
+    request(withHeaders({ "some-header": "some-header-value" })),
+    data({ response: "success" })
+  );
+
+  const headers = { "some-header": "some-header-value" };
+  const response = await graphqlQuery('TestQuery', {headers});
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("mocks mutation response including header data", async () => {
+  when(mutation("TestMutation")).thenReturnFor(
+    request(withHeaders({ "some-header": "some-header-value" })),
+    data({ response: "success" })
+  );
+
+  const headers = { "some-header": "some-header-value" };
+  const response = await graphqlMutation('TestMutation', {headers});
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.data).toStrictEqual({ response: "success" });
+});
+
+test("query response mock fails without correct queryName", async () => {
+  when(query("TestQuery")).thenReturnFor(
+    request(),
+    data({ response: "success" })
+  );
+
+  const testRequest = async () =>
+    await graphqlQuery('AnotherQuery');
+  
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("mutation response mock fails without correct queryName", async () => {
+  when(mutation("TestMutation")).thenReturnFor(
+    request(),
+    data({ response: "success" })
+  );
+
+  const testRequest = async () =>
+    await graphqlMutation('AnotherMutation');
+  
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("query response fails without correct header data", async () => {
+  when(query("TestQuery")).thenReturnFor(
+    request(withHeaders({ "some-header": "some-header-value" })),
+    data({ response: "success" })
+  );
+
+  const testRequest = async () =>
+   await graphqlQuery('TestQuery', 
+      {headers: { "some-header": "some other header value" }});
+
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("mutation response fails without correct header data", async () => {
+  when(mutation("TestMutation")).thenReturnFor(
+    request(withHeaders({ "some-header": "some-header-value" })),
+    data({ response: "success" })
+  );
+
+  const testRequest = async () =>
+   await graphqlMutation('TestMutation', 
+      {headers: { "some-header": "some other header value" }});
+
+  await expect(testRequest()).rejects.toThrow();
+});
+
+test("mocks query response returning errors", async () => {
+  when(query("TestQuery")).thenReturn(
+    errors([{ message: "test error" }])
+  );
+
+  const response = await graphqlQuery('TestQuery');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks mutation response returning errors", async () => {
+  when(mutation("TestMutation")).thenReturn(
+    errors([{ message: "test error" }])
+  );
+
+  const response = await graphqlMutation('TestMutation');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks query response returning errors with ", async () => {
+  when(query("TestQuery")).thenReturn(
+    errors([{ message: "test error" }])
+  );
+
+  const response = await graphqlQuery('TestQuery');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks query response returning errors with thenReturnFor", async () => {
+  when(query("TestQuery")).thenReturnFor(
+    request(),
+    errors([{ message: "test error" }])
+  );
+
+  const response = await graphqlQuery('TestQuery');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks mutation response returning errors with thenReturnFor", async () => {
+  when(mutation("TestMutation")).thenReturnFor(
+    request(),
+    errors([{ message: "test error" }])
+  );
+
+  const response = await graphqlMutation('TestMutation');
+
+  const json = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(json.errors).toStrictEqual([{ message: "test error" }]);
+});

--- a/tests/MswWhenGraphQLTest.test.js
+++ b/tests/MswWhenGraphQLTest.test.js
@@ -19,18 +19,20 @@ beforeAll(() => server.listen());
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-const graphqlAction = (url, query, options={}) => {
-  const contentTypeHeader = { 'Content-Type': 'application/json'}
-  const headers = options.headers ? {...contentTypeHeader, ...options.headers} : contentTypeHeader;
+const graphqlAction = (url, query, options = {}) => {
+  const contentTypeHeader = { "Content-Type": "application/json" };
+  const headers = options.headers
+    ? { ...contentTypeHeader, ...options.headers }
+    : contentTypeHeader;
 
   const allOptions = {
-    method: 'POST',
+    method: "POST",
     headers,
-    body: JSON.stringify({ query })
-  }
+    body: JSON.stringify({ query }),
+  };
 
   return fetch(url, allOptions);
-}
+};
 
 const buildQuery = (queryName) => `
   query ${queryName} {
@@ -48,15 +50,15 @@ const buildMutation = (queryName) => `
   }
 `;
 
-const graphqlQuery = (queryName, options) => 
+const graphqlQuery = (queryName, options) =>
   graphqlAction("https://some.url", buildQuery(queryName), options);
-const graphqlMutation = (mutationName, options) => 
+const graphqlMutation = (mutationName, options) =>
   graphqlAction("https://some.url", buildMutation(mutationName), options);
 
 test("mocks query response with thenReturn", async () => {
   when(query("TestQuery")).thenReturn(data({ response: "success" }));
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
 
   const json = await response.json();
 
@@ -67,7 +69,7 @@ test("mocks query response with thenReturn", async () => {
 test("mocks mutation response with thenReturn", async () => {
   when(mutation("TestMutation")).thenReturn(data({ response: "success" }));
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
 
   const json = await response.json();
 
@@ -78,13 +80,13 @@ test("mocks mutation response with thenReturn", async () => {
 test("mocks query response with thenReturn for multiple fetches", async () => {
   when(query("TestQuery")).thenReturn(data({ response: "success" }));
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
   const json = await response.json();
-  
+
   expect(response.status).toBe(200);
   expect(json.data).toStrictEqual({ response: "success" });
-  
-  const response2 = await graphqlQuery('TestQuery');
+
+  const response2 = await graphqlQuery("TestQuery");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
@@ -94,13 +96,13 @@ test("mocks query response with thenReturn for multiple fetches", async () => {
 test("mocks mutation response with thenReturn for multiple fetches", async () => {
   when(mutation("TestMutation")).thenReturn(data({ response: "success" }));
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
   const json = await response.json();
-  
+
   expect(response.status).toBe(200);
   expect(json.data).toStrictEqual({ response: "success" });
-  
-  const response2 = await graphqlMutation('TestMutation');
+
+  const response2 = await graphqlMutation("TestMutation");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
@@ -112,7 +114,7 @@ test("mocks query response with then", async () => {
     res(ctx.data({ response: "success" }))
   );
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
   const json = await response.json();
 
   expect(response.status).toBe(200);
@@ -124,7 +126,7 @@ test("mocks mutation response with then", async () => {
     res(ctx.data({ response: "success" }))
   );
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
   const json = await response.json();
 
   expect(response.status).toBe(200);
@@ -136,13 +138,13 @@ test("mocks query response with then for multiple fetches", async () => {
     res(ctx.data({ response: "success" }))
   );
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
   const json = await response.json();
 
   expect(response.status).toBe(200);
   expect(json.data).toStrictEqual({ response: "success" });
 
-  const response2 = await graphqlQuery('TestQuery');
+  const response2 = await graphqlQuery("TestQuery");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
@@ -154,13 +156,13 @@ test("mocks mutation response with then for multiple fetches", async () => {
     res(ctx.data({ response: "success" }))
   );
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
   const json = await response.json();
 
   expect(response.status).toBe(200);
   expect(json.data).toStrictEqual({ response: "success" });
 
-  const response2 = await graphqlMutation('TestMutation');
+  const response2 = await graphqlMutation("TestMutation");
   const json2 = await response2.json();
 
   expect(response2.status).toBe(200);
@@ -173,7 +175,7 @@ test("mocking query response with empty request data acts like thenReturn", asyn
     data({ response: "success" })
   );
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
 
   const json = await response.json();
 
@@ -187,7 +189,7 @@ test("mocking mutation response with empty request data acts like thenReturn", a
     data({ response: "success" })
   );
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
 
   const json = await response.json();
 
@@ -202,7 +204,7 @@ test("mocks query response including header data", async () => {
   );
 
   const headers = { "some-header": "some-header-value" };
-  const response = await graphqlQuery('TestQuery', {headers});
+  const response = await graphqlQuery("TestQuery", { headers });
 
   const json = await response.json();
 
@@ -217,7 +219,7 @@ test("mocks mutation response including header data", async () => {
   );
 
   const headers = { "some-header": "some-header-value" };
-  const response = await graphqlMutation('TestMutation', {headers});
+  const response = await graphqlMutation("TestMutation", { headers });
 
   const json = await response.json();
 
@@ -231,9 +233,8 @@ test("query response mock fails without correct queryName", async () => {
     data({ response: "success" })
   );
 
-  const testRequest = async () =>
-    await graphqlQuery('AnotherQuery');
-  
+  const testRequest = async () => await graphqlQuery("AnotherQuery");
+
   await expect(testRequest()).rejects.toThrow();
 });
 
@@ -243,9 +244,8 @@ test("mutation response mock fails without correct queryName", async () => {
     data({ response: "success" })
   );
 
-  const testRequest = async () =>
-    await graphqlMutation('AnotherMutation');
-  
+  const testRequest = async () => await graphqlMutation("AnotherMutation");
+
   await expect(testRequest()).rejects.toThrow();
 });
 
@@ -256,8 +256,9 @@ test("query response fails without correct header data", async () => {
   );
 
   const testRequest = async () =>
-   await graphqlQuery('TestQuery', 
-      {headers: { "some-header": "some other header value" }});
+    await graphqlQuery("TestQuery", {
+      headers: { "some-header": "some other header value" },
+    });
 
   await expect(testRequest()).rejects.toThrow();
 });
@@ -269,18 +270,17 @@ test("mutation response fails without correct header data", async () => {
   );
 
   const testRequest = async () =>
-   await graphqlMutation('TestMutation', 
-      {headers: { "some-header": "some other header value" }});
+    await graphqlMutation("TestMutation", {
+      headers: { "some-header": "some other header value" },
+    });
 
   await expect(testRequest()).rejects.toThrow();
 });
 
 test("mocks query response returning errors", async () => {
-  when(query("TestQuery")).thenReturn(
-    errors([{ message: "test error" }])
-  );
+  when(query("TestQuery")).thenReturn(errors([{ message: "test error" }]));
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
 
   const json = await response.json();
 
@@ -293,7 +293,7 @@ test("mocks mutation response returning errors", async () => {
     errors([{ message: "test error" }])
   );
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
 
   const json = await response.json();
 
@@ -302,11 +302,9 @@ test("mocks mutation response returning errors", async () => {
 });
 
 test("mocks query response returning errors with ", async () => {
-  when(query("TestQuery")).thenReturn(
-    errors([{ message: "test error" }])
-  );
+  when(query("TestQuery")).thenReturn(errors([{ message: "test error" }]));
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
 
   const json = await response.json();
 
@@ -320,7 +318,7 @@ test("mocks query response returning errors with thenReturnFor", async () => {
     errors([{ message: "test error" }])
   );
 
-  const response = await graphqlQuery('TestQuery');
+  const response = await graphqlQuery("TestQuery");
 
   const json = await response.json();
 
@@ -334,7 +332,7 @@ test("mocks mutation response returning errors with thenReturnFor", async () => 
     errors([{ message: "test error" }])
   );
 
-  const response = await graphqlMutation('TestMutation');
+  const response = await graphqlMutation("TestMutation");
 
   const json = await response.json();
 

--- a/tests/MswWhenGraphQLTestChaining.test.js
+++ b/tests/MswWhenGraphQLTestChaining.test.js
@@ -1,0 +1,132 @@
+const { graphql } = require("msw");
+const { setupServer } = require("msw/node");
+const { whenThenGraphQL, query, data, errors } = require("../src");
+const fetch = require("node-fetch");
+
+const server = setupServer();
+
+const { when } = whenThenGraphQL(server, graphql);
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+const graphqlQuery = (queryName) => {
+  const query = `
+    query ${queryName} {
+      user {
+        id
+      }
+    }
+  `;
+
+  const options = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  };
+
+  return fetch("https://some.url", options);
+};
+
+test("mocks chained responses with thenReturn", async () => {
+  when(query("TestQuery"))
+    .thenReturn(data({ response: "response1" }))
+    .thenReturn(errors([{ message: "test error" }]));
+
+  const response1 = await graphqlQuery("TestQuery");
+  const json1 = await response1.json();
+
+  expect(response1.status).toBe(200);
+  expect(json1.data).toStrictEqual({ response: "response1" });
+
+  const response2 = await graphqlQuery("TestQuery");
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks chained responses with then", async () => {
+  when(query("TestQuery"))
+    .then((req, res, ctx) => res(ctx.data({ response: "response1" })))
+    .then((req, res, ctx) => res(ctx.errors([{ message: "test error" }])));
+
+  const response1 = await graphqlQuery("TestQuery");
+  const json1 = await response1.json();
+
+  expect(response1.status).toBe(200);
+  expect(json1.data).toStrictEqual({ response: "response1" });
+
+  const response2 = await graphqlQuery("TestQuery");
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("mocks chained responses with mix of thenReturn and then", async () => {
+  when(query("TestQuery"))
+    .thenReturn(data({ response: "response1" }))
+    .then((req, res, ctx) => res(ctx.errors([{ message: "test error" }])));
+
+  const response1 = await graphqlQuery("TestQuery");
+  const json1 = await response1.json();
+
+  expect(response1.status).toBe(200);
+  expect(json1.data).toStrictEqual({ response: "response1" });
+
+  const response2 = await graphqlQuery("TestQuery");
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("last response with chained mocks is used with multiple fetches with then", async () => {
+  when(query("TestQuery"))
+    .thenReturn(data({ response: "response1" }))
+    .then((req, res, ctx) => res(ctx.errors([{ message: "test error" }])));
+
+  const response1 = await graphqlQuery("TestQuery");
+  const json1 = await response1.json();
+
+  expect(response1.status).toBe(200);
+  expect(json1.data).toStrictEqual({ response: "response1" });
+
+  const response2 = await graphqlQuery("TestQuery");
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.errors).toStrictEqual([{ message: "test error" }]);
+
+  const response3 = await graphqlQuery("TestQuery");
+  const json3 = await response3.json();
+
+  expect(response3.status).toBe(200);
+  expect(json3.errors).toStrictEqual([{ message: "test error" }]);
+});
+
+test("last response with chained mocks is used with multiple fetches with thenReturn", async () => {
+  when(query("TestQuery"))
+    .then((req, res, ctx) => res(ctx.data({ response: "response1" })))
+    .thenReturn(errors([{ message: "test error" }]));
+
+  const response1 = await graphqlQuery("TestQuery");
+  const json1 = await response1.json();
+
+  expect(response1.status).toBe(200);
+  expect(json1.data).toStrictEqual({ response: "response1" });
+
+  const response2 = await graphqlQuery("TestQuery");
+  const json2 = await response2.json();
+
+  expect(response2.status).toBe(200);
+  expect(json2.errors).toStrictEqual([{ message: "test error" }]);
+
+  const response3 = await graphqlQuery("TestQuery");
+  const json3 = await response3.json();
+
+  expect(response3.status).toBe(200);
+  expect(json3.errors).toStrictEqual([{ message: "test error" }]);
+});


### PR DESCRIPTION
 As a `BDD` and `DRY` practitioner I found your library very useful but discovered that you just provided the `Rest API `compatibility so I decided to contribute with this PR to allow mocking `GraphQL APIs`. Thanks for your nice work! 

There is some duplication between original `WhenThen.js` and new `WhenThenGraphQL.js`  files. I decided to leave it explicit to make the PR review easier and then maybe we can refactor it a bit.